### PR TITLE
Add webhook server to glue-service

### DIFF
--- a/glue-service/.env.example
+++ b/glue-service/.env.example
@@ -1,0 +1,3 @@
+CAL_WEBHOOK_SECRET=your_secret
+ATTENDEE_URL=http://attendee:8000
+PORT=4000

--- a/glue-service/package-lock.json
+++ b/glue-service/package-lock.json
@@ -9,7 +9,10 @@
       "version": "0.1.0",
       "dependencies": {
         "axios": "^1.6.7",
-        "express": "^4.19.2"
+        "body-parser": "^1.20.2",
+        "dotenv": "^16.4.5",
+        "express": "^4.19.2",
+        "raw-body": "^2.5.2"
       }
     },
     "node_modules/accepts": {
@@ -193,6 +196,18 @@
       "engines": {
         "node": ">= 0.8",
         "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "16.6.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
+      "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
       }
     },
     "node_modules/dunder-proto": {

--- a/glue-service/package.json
+++ b/glue-service/package.json
@@ -2,13 +2,16 @@
   "name": "glue-service",
   "version": "0.1.0",
   "private": true,
-  "type": "commonjs",
+  "type": "module",
   "scripts": {
-    "start": "node src/index.js",
-    "test": "echo \"No tests specified\" && exit 0"
+    "start": "node server.js",
+    "test": "echo \"no tests yet\""
   },
   "dependencies": {
     "axios": "^1.6.7",
-    "express": "^4.19.2"
+    "body-parser": "^1.20.2",
+    "dotenv": "^16.4.5",
+    "express": "^4.19.2",
+    "raw-body": "^2.5.2"
   }
 }

--- a/glue-service/server.js
+++ b/glue-service/server.js
@@ -1,0 +1,68 @@
+import express from "express";
+import crypto from "crypto";
+import axios from "axios";
+import getRawBody from "raw-body";
+import dotenv from "dotenv";
+
+dotenv.config();
+
+const app = express();
+
+async function parseJson(req, res, next) {
+  if (req.headers["content-type"] !== "application/json") {
+    return res.status(415).send("Unsupported Media Type");
+  }
+  try {
+    req.rawBody = await getRawBody(req);
+    req.body = JSON.parse(req.rawBody.toString());
+    next();
+  } catch (err) {
+    next(err);
+  }
+}
+const { PORT = 4000, CAL_WEBHOOK_SECRET, ATTENDEE_URL } = process.env;
+
+function verifySignature(req, res, next) {
+  const signature = req.headers["cal-signature"];
+  if (!signature) return res.status(401).send("Missing signature");
+
+  const hmac = crypto.createHmac("sha256", CAL_WEBHOOK_SECRET);
+  hmac.update(req.rawBody);
+  const digest = hmac.digest("hex");
+
+  if (!crypto.timingSafeEqual(Buffer.from(digest), Buffer.from(signature))) {
+    return res.status(401).send("Invalid signature");
+  }
+  next();
+}
+
+async function pollTranscript(botId) {
+  const base = `${ATTENDEE_URL}/bots/${botId}`;
+  let delay = 5000;
+  for (let i = 0; i < 12; i++) {
+    await new Promise((r) => setTimeout(r, delay));
+    const resp = await axios.get(base);
+    if (resp.data.transcription_state === "complete") {
+      return axios.get(`${base}/transcript`);
+    }
+    delay = Math.min(60000, delay * 2);
+  }
+  throw new Error("Polling timed out");
+}
+
+app.post("/webhook", parseJson, verifySignature, async (req, res) => {
+  try {
+    const meetingUrl = req.body.payload.conferencing.join_url;
+    const createResp = await axios.post(`${ATTENDEE_URL}/bots`, { meetingUrl });
+    const { id: botId } = createResp.data;
+    const transcriptResp = await pollTranscript(botId);
+    // TODO: save transcriptResp.data into your DB
+    console.log("Transcript:", transcriptResp.data);
+    res.status(200).send("Processed");
+  } catch (err) {
+    console.error(err);
+    res.status(500).send("Error processing webhook");
+  }
+});
+
+app.listen(PORT, () => console.log(`Listening on ${PORT}`));


### PR DESCRIPTION
## Summary
- add dotenv setup for glue-service
- expose a new `server.js` implementing webhook signature verification and transcript polling
- install body-parser and raw-body for reading request bodies
- document example environment variables
- update package scripts to run the new server
- fix raw body handling for the webhook endpoint

## Testing
- `npm install` in `glue-service`
- `npm test` in `glue-service`


------
https://chatgpt.com/codex/tasks/task_e_685f9a4076608333a945f7575213395f